### PR TITLE
Fix build and run on Alpine Linux

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,6 +5,7 @@ KDIR = @KDIR@
 KINSTDIR = $(shell dirname @KDIR@)
 IPTABLES_CFLAGS = @IPTABLES_CFLAGS@
 IPTABLES_MODULES = @IPTABLES_MODULES@
+DEPMOD = depmod -a
 
 # https://www.kernel.org/doc/Documentation/kbuild/modules.txt
 # https://www.kernel.org/doc/Documentation/kbuild/makefiles.txt
@@ -22,7 +23,7 @@ sparse: | version.h ipt_NETFLOW.c ipt_NETFLOW.h Makefile
 	@touch ipt_NETFLOW.ko
 minstall: | ipt_NETFLOW.ko
 	make -C $(KDIR) M=$(CURDIR) modules_install INSTALL_MOD_PATH=$(DESTDIR)
-	depmod -a
+	$(DEPMOD)
 mclean:
 	make -C $(KDIR) M=$(CURDIR) clean
 lclean:

--- a/ipt_NETFLOW.c
+++ b/ipt_NETFLOW.c
@@ -488,8 +488,13 @@ static struct file_operations nf_seq_fops = {
 #define BEFORE2632(x,y)
 #endif
 
+/* PAX need to know that we are allowed to write */
+#ifndef CONSTIFY_PLUGIN
+#define ctl_table_no_const ctl_table
+#endif
+
 /* sysctl /proc/sys/net/netflow */
-static int hsize_procctl(ctl_table *ctl, int write, BEFORE2632(struct file *filp,)
+static int hsize_procctl(ctl_table_no_const *ctl, int write, BEFORE2632(struct file *filp,)
 			 void __user *buffer, size_t *lenp, loff_t *fpos)
 {
 	void *orig = ctl->data;
@@ -507,7 +512,7 @@ static int hsize_procctl(ctl_table *ctl, int write, BEFORE2632(struct file *filp
 		return ret;
 }
 
-static int sndbuf_procctl(ctl_table *ctl, int write, BEFORE2632(struct file *filp,)
+static int sndbuf_procctl(ctl_table_no_const *ctl, int write, BEFORE2632(struct file *filp,)
 			 void __user *buffer, size_t *lenp, loff_t *fpos)
 {
 	int ret;
@@ -569,7 +574,7 @@ static int aggregation_procctl(ctl_table *ctl, int write, BEFORE2632(struct file
 	return ret;
 }
 
-static int flush_procctl(ctl_table *ctl, int write, BEFORE2632(struct file *filp,)
+static int flush_procctl(ctl_table_no_const *ctl, int write, BEFORE2632(struct file *filp,)
 			 void __user *buffer, size_t *lenp, loff_t *fpos)
 {
 	int ret;


### PR DESCRIPTION
Help packagers to disable run of depmod since the build server might not run the same kernel as the runtime target.

Also add support for PAX's [constify](http://lwn.net/Articles/461696/) feature.