### PR TITLE
Allow setting observation domain ID based on local hostname

### DIFF
--- a/README
+++ b/README
@@ -254,6 +254,13 @@ ipt_NETFLOW linux 2.6.x-4.x kernel module by <abc@telekom.ru> -- 2008-2016.
 	 labels you want to be recorded and exported (default is 3, maximum is
 	 10, set to 0 to not report anything).
 
+     --enable-source-id-from-hostname
+	 Sets the Observation Domain ID (IPFIX)/Source ID (NetFlow) of exported
+	 flow data to a value based on the hostname of the local machine.
+	 This is usefuly if your collector has no other way of distinguishing
+	 between multple exporters.  If this option isn't enabled this value
+	 is always set to 0.
+
 
 ===========
 = RUNNING =

--- a/configure
+++ b/configure
@@ -275,6 +275,7 @@ show_help() {
   echo "  --promisc-mpls=N       -- and record N labels (default 3)"
   echo "  --enable-physdev       enables physdev reporting"
   echo "  --enable-physdev-override      to override interfaces"
+  echo "  --enable-source-id-from-hostname enables setting the Observation Domain to a hash of the hostname"
   echo "  --disable-snmp-agent   disables net-snmp agent"
   echo "  --disable-dkms         disables DKMS support completely"
   echo "  --disable-dkms-install  no DKMS install but still create dkms.conf"
@@ -309,6 +310,7 @@ do
     --enable-snmp-r*)  KOPTS="$KOPTS -DENABLE_SNMP" ;;
     --enable-physdev)       KOPTS="$KOPTS -DENABLE_PHYSDEV" ;;
     --enable-physdev-over*) KOPTS="$KOPTS -DENABLE_PHYSDEV_OVER" ;;
+    --enable-source-id-fro*) KOPTS="$KOPTS -DENABLE_SOURCE_ID_FROM_HOSTNAME" ;;
     --disable-snmp-a*)   SKIPSNMP=1 ;;
     --disable-net-snmp*) SKIPSNMP=1 ;;
     --disable-dkms*)     SKIPDKMS=1 ;;


### PR DESCRIPTION
I have a use-case where a collector is getting flows from multiple exporters, but isn't able to use the source IP address to distinguish between exporters.

Inside ipt_NETFLOW.c, engine_id is a static int set to 0 (and never changed), which is then used to set Engine ID (v5), Source ID (v9) and Observation Domain ID (IPFIX).

This PR adds the option --enable-source-id-from-hostname at build time, which sets engine_id to a hash of the system hostname during module init.  It also masks engine_id to 8 bits when sending out a v5 PDU because of the smaller allocated space.

There should be no effect if the option isn't enabled at compile time.