### PR TITLE
Fix configure for dkms

### DIFF
--- a/configure
+++ b/configure
@@ -312,7 +312,7 @@ do
     --disable-snmp-a*)   SKIPSNMP=1 ;;
     --disable-net-snmp*) SKIPSNMP=1 ;;
     --disable-dkms*)     SKIPDKMS=1 ;;
-    --from-dkms-conf) ;;
+    --from-dkms-conf*) ;;
     --make) echo called from make; CARGS=`echo $CARGS | sed s/--make//g` ;;
     -Werror) KOPTS="$KOPTS -Werror" ;;
     --help|-h) show_help ;;


### PR DESCRIPTION
dkms runs ./configure --from-dkms-conf=$kernel_source_dir. Without this
./configure fails with invalid option. Change the check to match the one
at the top of the file.