### PR TITLE
iptables-dev is a transitional package since Debian 8 and Ubuntu 16.10

### DIFF
--- a/README
+++ b/README
@@ -111,7 +111,8 @@ ipt_NETFLOW linux 2.6.x-4.x kernel module by <abc@openwall.com> -- 2008-2018.
    Before this step it also would be useful to install pkg-config if don't
    already have.
 
-   If you have package system just install iptables-devel (or iptables-dev)
+   If you have package system just install iptables-devel (or on Debian, Ubuntu
+   and derivatives libxtables-dev if available, otherwise iptables-dev)
    package, otherwise install iptables source matching version of your
    installation from ftp://ftp.netfilter.org/pub/iptables/
 

--- a/configure
+++ b/configure
@@ -247,7 +247,11 @@ iptables_try_pkgconfig() {
     if [ -s /etc/debian_version ]; then
       echo "! "
       echo "! Under Debian simply run this:"
-      echo "!   root# apt-get install iptables-dev pkg-config"
+      if apt-cache policy libxtables-dev 2>&1 | fgrep -q "Candidate:"; then
+        echo "!   root# apt-get install libxtables-dev pkg-config"
+      else
+        echo "!   root# apt-get install iptables-dev pkg-config"
+      fi
     elif [ -s /etc/redhat-release ]; then
       echo "! "
       arch=.`uname -m`


### PR DESCRIPTION
Check if we should suggest to install libxtables-dev instead (i.e. if
it exists).

Also document this in the README.