### PR TITLE
natevents: optimize export

### DIFF
--- a/ipt_NETFLOW.c
+++ b/ipt_NETFLOW.c
@@ -4577,11 +4577,10 @@ static int netflow_conntrack_event(struct notifier_block *this, unsigned long ev
 		return ret;
 	}
 
-	if (!(nel = kmalloc(sizeof(struct nat_event), GFP_ATOMIC))) {
+	if (!(nel = kzalloc(sizeof(struct nat_event), GFP_ATOMIC))) {
 		printk(KERN_ERR "ipt_NETFLOW: can't kmalloc nat event\n");
 		return ret;
 	}
-	memset(nel, 0, sizeof(struct nat_event));
 	nel->ts_ktime = ktime_get_real();
 	nel->ts_jiffies = jiffies;
 	t = &ct->tuplehash[IP_CT_DIR_ORIGINAL].tuple;

--- a/ipt_NETFLOW.c
+++ b/ipt_NETFLOW.c
@@ -4605,17 +4605,17 @@ static int netflow_conntrack_event(struct notifier_block *this, unsigned long ev
 		nat_events_stop++;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39)
 		if (likely(tstamp))
-			nel->ts_ktime = tstamp->stop;
+			nel->ts_ktime = ktime_set(0, tstamp->stop);
 #endif /* after 2.6.38 */
 	} else {
 		nel->nat_event = NAT_CREATE;
 		nat_events_start++;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39)
 		if (likely(tstamp))
-			nel->ts_ktime = tstamp->start;
+			nel->ts_ktime = ktime_set(0, tstamp->start);
 #endif /* after 2.6.38 */
 	}
-	if (!nel->ts_ktime)
+	if (ktime_to_ns(nel->ts_ktime) == 0)
 		nel->ts_ktime = ktime_get_real();
 
 	spin_lock_bh(&nat_lock);


### PR DESCRIPTION
* Use export list to minimize spinlock pressure
* Use conntrack time start/stop
* Use kzalloc() instead of memset()