### PR TITLE
dkms: add gen_compat_def to dkms sources

### DIFF
--- a/install-dkms.sh
+++ b/install-dkms.sh
@@ -95,7 +95,7 @@ echo "! Installing $MVERSION into DKMS..."
 rm -rf /usr/src/ipt-netflow-$MVERSION
 
 mkdir -p /usr/src/ipt-netflow-$MVERSION
-cp -p *.[ch] Make* READ* conf* irq* *.sh *.conf /usr/src/ipt-netflow-$MVERSION/
+cp -p *.[ch] Make* READ* conf* gen* irq* *.sh *.conf /usr/src/ipt-netflow-$MVERSION/
 if [ -d .git ]; then
   cp -pr .git /usr/src/ipt-netflow-$MVERSION/
 fi


### PR DESCRIPTION
DKMS installation forgets to copy gen_compat_def scipt to sources directory, making it impossible to build dkms module