### PR TITLE
Compatibility with kernel 5.7

### DIFF
--- a/ipt_NETFLOW.c
+++ b/ipt_NETFLOW.c
@@ -3515,11 +3515,13 @@ static inline __u8 hook2dir(const __u8 hooknum)
 }
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)
 static inline void put_unaligned_be24(u32 val, unsigned char *p)
 {
 	*p++ = val >> 16;
 	put_unaligned_be16(val, p);
 }
+#endif
 
 static struct {
 	s64		ms;	 /* this much abs milliseconds */


### PR DESCRIPTION
After commit a7afff31d56db22647251d76d6af030cd47bd97e "scsi: treewide: Consolidate
{get,put}_unaligned_[bl]e24() definitions", build fails due to:

...
  CC [M]  /home/ubuntu/ipt-netflow/iptables-netflow/ipt_NETFLOW.o
/home/ubuntu/ipt-netflow/iptables-netflow/ipt_NETFLOW.c:3518:20: error:
conflicting types for ‘put_unaligned_be24’
 3518 | static inline void put_unaligned_be24(u32 val, unsigned char *p)
      |                    ^~~~~~~~~~~~~~~~~~
In file included from ./arch/x86/include/asm/unaligned.h:10,
                 from ./include/linux/etherdevice.h:23,
                 from ./include/linux/if_vlan.h:11,
                 from ./include/linux/filter.h:22,
                 from ./include/net/sock.h:59,
                 from ./include/net/inet_sock.h:22,
                 from ./include/linux/udp.h:16,
                 from
/home/ubuntu/ipt-netflow/iptables-netflow/ipt_NETFLOW.c:32:
./include/linux/unaligned/generic.h:98:20: note: previous definition of
‘put_unaligned_be24’ was here
   98 | static inline void put_unaligned_be24(const u32 val, void *p)
...

Fix it by hiding the local version if Linux > 5.6

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>