### PR TITLE
snmp: Include unistd.h for access/close/read/write

### DIFF
--- a/snmp_NETFLOW.c
+++ b/snmp_NETFLOW.c
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>


### PR DESCRIPTION
Fixes a few compiler warnings:
```
snmp_NETFLOW.c:179:6: warning: implicit declaration of function ‘access’; did you mean ‘accept’?
snmp_NETFLOW.c:189:10: warning: implicit declaration of function ‘read’; did you mean ‘fread’?
snmp_NETFLOW.c:191:3: warning: implicit declaration of function ‘close’; did you mean ‘pclose’?
snmp_NETFLOW.c:225:6: warning: implicit declaration of function ‘write’; did you mean ‘fwrite’?
```