### PR TITLE
Fix race condition during gen_compat_def on filesystems w/o microseco…

### DIFF
--- a/gen_compat_def
+++ b/gen_compat_def
@@ -26,7 +26,7 @@ kbuild_test_compile() {
 
   cat > test.c
   echo obj-m = test.o > Makefile
-  cmd="make -s -C $KDIR M=$PWD modules"
+  cmd="make -s -B -C $KDIR M=$PWD modules"
   echo "$cmd" > log
   if $cmd >> log 2>&1; then
     echo " declared" >&2


### PR DESCRIPTION
…nd resolution

This fixes a rather obscure but difficult to track race condition which
can occur when the code is compiled on a file system without
microseconds ctime/mtime resolution.

Because gen_compat_def overwrites the same test.c for every
kbuild_test_compile() run, on fast systems this can happen in the same
second as the last test, causing make to skip the compilation (and thus
the whole test), leading to errors later during module build.

I think this was the cause for
https://github.com/aabc/ipt-netflow/issues/152 as I ran into the exact
same error.

This is also Debian Bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=972455

This commit here fixes this by adding -B to make to force it to rebuild
every thing every time and not use timestamps to optimize the build
process.

A different solution would be to create a different temporary directory
for each kbuild_test_compile() run, but I opted for the less invasive
change.