### PR TITLE
ipt_netflow: optionally seed initial template ID from PRNG

### DIFF
--- a/configure
+++ b/configure
@@ -302,6 +302,7 @@ show_help() {
   echo "  --enable-direction     enables flowDirection(61) Element"
   echo "  --enable-sampler       enables Flow Sampling"
   echo "  --enable-sampler=hash  enables Hash sampler"
+  echo "  --enable-rand-tpl-id   enables seeding the template IDs from a random number"
   echo "  --enable-aggregation   enables aggregation rules"
   echo "  --enable-promisc       enables promisc hack mode"
   echo "  --promisc-mpls         decapsulate MPLS in promisc mode"
@@ -337,6 +338,7 @@ do
     --enable-sampl*hash) KOPTS="$KOPTS -DENABLE_SAMPLER -DSAMPLING_HASH" ;;
     --enable-sampl*) KOPTS="$KOPTS -DENABLE_SAMPLER" ;;
     --enable-aggr*)  KOPTS="$KOPTS -DENABLE_AGGR" ;;
+    --enable-rand-tpl*)  KOPTS="$KOPTS -DENABLE_RANDOM_TEMPLATE_IDS" ;;
     --enable-promi*)   ENABLE_PROMISC=1 ;;
     --promisc-mpls*)   ENABLE_PROMISC=1; PROMISC_MPLS=1; MPLS_DEPTH=${ac_optarg:-3} ;;
     --enable-snmp-r*)  KOPTS="$KOPTS -DSNMP_RULES" ;;


### PR DESCRIPTION
If we're always starting from 256, a module reload could result in the
client getting data under template IDs that were used under the previous
configuration and might not match (or worse, wrongly match). We add a
compilation option to start the template ID range from a random number,
reducing greatly the chances of such an accident occuring.

Since we're starting from a random number, we now have to check for
wrapping, as the random number might be close to 0xFFFF, which would
mean exporting template with IDs under 256 that are reserved.

v2: Fix the log output by keeping a separate count of the templates
generated by the module.

Signed-off-by: Simon Chopin <s.chopin@alphalink.fr>