### PR TITLE
fix building on old kernels

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -782,7 +782,14 @@ struct module *find_module(const char *name)
 #endif
 
 #ifndef HAVE_NF_CT_EVENT_NOTIFIER_CT_EVENT
+/*
+ * nat event callback parameter is constified in 5.15+
+ * but it prevents module building with previous kernel versions
+ */
+# define NF_CT_EVENT struct nf_ct_event
 # define ct_event fcn
+#else
+# define NF_CT_EVENT const struct nf_ct_event
 #endif
 
 #endif /* COMPAT_NETFLOW_H */

--- a/ipt_NETFLOW.c
+++ b/ipt_NETFLOW.c
@@ -4597,7 +4597,7 @@ static void rate_timer_calc(
 #ifdef CONFIG_NF_NAT_NEEDED
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,31)
 static struct nf_ct_event_notifier *saved_event_cb __read_mostly = NULL;
-static int netflow_conntrack_event(const unsigned int events, const struct nf_ct_event *item)
+static int netflow_conntrack_event(const unsigned int events, NF_CT_EVENT *item)
 #else
 static int netflow_conntrack_event(struct notifier_block *this, unsigned long events, void *ptr)
 #endif


### PR DESCRIPTION
const qualifier is added to conntrack callback only in 5.15+, but it breaks build on previous versions.