### PR TITLE
Fix preemptive enabled warning

### DIFF
--- a/ipt_NETFLOW.c
+++ b/ipt_NETFLOW.c
@@ -4501,7 +4501,7 @@ static void netflow_work_fn(struct work_struct *dummy)
 	wk_count = 0;
 	wk_trylock = 0;
 	wk_llist = 0;
-	wk_cpu = smp_processor_id();
+	wk_cpu = __smp_processor_id();
 	wk_start = jiffies;
 
 	pdus = netflow_scan_and_export(DONT_FLUSH);


### PR DESCRIPTION
Issue #193 193, we can use unstable reading because we actually don't
care much of actual CPU that executed worker